### PR TITLE
Use field with null in Datastore

### DIFF
--- a/google-cloud/src/datastore/client.rs
+++ b/google-cloud/src/datastore/client.rs
@@ -354,6 +354,7 @@ fn convert_entity(project_name: &str, entity: Entity) -> api::Entity {
 
 fn convert_value(project_name: &str, value: Value) -> api::Value {
     let value_type = match value {
+        Value::NULL(_) => api::value::ValueType::NullValue(0),
         Value::BooleanValue(val) => ValueType::BooleanValue(val),
         Value::IntegerValue(val) => ValueType::IntegerValue(val),
         Value::DoubleValue(val) => ValueType::DoubleValue(val),


### PR DESCRIPTION
Without the NULL type, it was necessary to replicate the entire structure of the entity type fields with empty values for Datastore to support the structure